### PR TITLE
Exclude calc layer from getting bundled

### DIFF
--- a/lib/cdk-starter-stack.ts
+++ b/lib/cdk-starter-stack.ts
@@ -38,7 +38,7 @@ export class CdkStarterStack extends cdk.Stack {
         minify: false,
         // 👇 don't bundle `yup` layer
         // layers are already available in the lambda env
-        externalModules: ['aws-sdk', 'yup'],
+        externalModules: ['aws-sdk', 'yup', '/opt/nodejs/calc'],
       },
       layers: [calcLayer, yupLayer],
     });


### PR DESCRIPTION
Hey @bobbyhadz - thanks for putting this repo and associated blog post together. It really helped to get started with Lambda Layers!!

One thing I noticed was that the `double` function was not using the library stored in `/opt/nodejs`. Rather it was being bundled into the actual lambda. I _think_ we need to exclude it through the `externalModules` in the CDK Lambda construct. Maybe there's another (better?) way to do this but it seemed to work for me.

Thanks again!